### PR TITLE
Adds basic UI feedback to Manual Start button.

### DIFF
--- a/src/Resources/public/js/pimcore/configuration/configItemDataObject.js
+++ b/src/Resources/public/js/pimcore/configuration/configItemDataObject.js
@@ -402,37 +402,45 @@ pimcore.plugin.storeExporterDataObject.configuration.configItemDataObject =
             params: {
               name: this.data.general.name,
             },
+            success: () => {        
+              Ext.MessageBox.show({
+                title:t('plugin_pimcore_datahub_configpanel_item_execution'),
+                msg: t('plugin_pimcore_datahub_configpanel_item_queue_started'),
+                buttons: Ext.Msg.OK ,
+                icon: Ext.MessageBox.INFO,
+              }); 
+            },
           });
         }.bind(this),
       });
-      if (!this.logStore) {
-        this.logStore = Ext.create("Ext.data.Store", {
-          fields: ["comment", "log"],
-          data: this.data.ExportLogs ?? [],
-          pageSize: 0,
-        });
-      }
-      let logPanel = Ext.create("Ext.grid.Panel", {
-        store: this.logStore,
-        viewConfig: {
-          forceFit: true,
-          enableTextSelection: true,
-        },
-        columns: [
-          {
-            text: "Log Comment",
-            dataIndex: "comment",
-            columnWidth: "5%",
-          },
-          {
-            text: "Log",
-            dataIndex: "log",
-            renderer: function (value, metaData) {
-              return '<div style="white-space:normal">' + value + "</div>";
-            },
-          },
-        ],
-      });
+      // if (!this.logStore) {
+      //   this.logStore = Ext.create("Ext.data.Store", {
+      //     fields: ["comment", "log"],
+      //     data: this.data.ExportLogs ?? [],
+      //     pageSize: 0,
+      //   });
+      // }
+      // let logPanel = Ext.create("Ext.grid.Panel", {
+      //   store: this.logStore,
+      //   viewConfig: {
+      //     forceFit: true,
+      //     enableTextSelection: true,
+      //   },
+      //   columns: [
+      //     {
+      //       text: "Log Comment",
+      //       dataIndex: "comment",
+      //       columnWidth: "5%",
+      //     },
+      //     {
+      //       text: "Log",
+      //       dataIndex: "log",
+      //       renderer: function (value, metaData) {
+      //         return '<div style="white-space:normal">' + value + "</div>";
+      //       },
+      //     },
+      //   ],
+      // });
       this.executionForm = Ext.create("Ext.form.FormPanel", {
         bodyStyle: "padding:10px;",
         autoScroll: true,
@@ -443,7 +451,7 @@ pimcore.plugin.storeExporterDataObject.configuration.configItemDataObject =
         border: false,
         title: t("plugin_pimcore_datahub_configpanel_item_execution"),
         //add some config for cron
-        items: [manualExecute, logPanel],
+        items: [manualExecute,], //, logPanel],
       });
       return this.executionForm;
     },

--- a/src/Resources/translations/admin.en.yaml
+++ b/src/Resources/translations/admin.en.yaml
@@ -12,6 +12,7 @@ plugin_pimcore_datahub_configpanel_item_reload_fields: Reload Remote Field Defin
 plugin_pimcore_datahub_configpanel_item_products: Choose Products
 plugin_pimcore_datahub_configpanel_item_execution: Execution
 plugin_pimcore_datahub_configpanel_item_manual_execute: Manual Start
+plugin_pimcore_datahub_configpanel_item_queue_started: This Export has been queued for processing.  See Logs for details.
 plugin_pimcore_datahub_configpanel_item_products_sql: Product Query Where Clause
 plugin_pimcore_datahub_configpanel_item_logs: Import Logs
 plugin_pimcore_datahub_configpanel_item_logs_openlog: Download Log File


### PR DESCRIPTION
Removes empty log preview from execution panel.  When the export job is triggered from the manual start button, a dialog shows this step to the admin user.