### PR TITLE
Feat/asynchronous

### DIFF
--- a/src/Services/Stores/BaseStore.php
+++ b/src/Services/Stores/BaseStore.php
@@ -80,26 +80,25 @@ abstract class BaseStore implements StoreInterface
             } else {
                 $localValue = $this->getFieldValues($object, $localFieldPath, $fieldType);
             }
-            if ($localValue !== null) {
-                if (!is_array($localValue)) {
-                    $localValue = [$localValue];
-                }
-                $value = array();
+            
+            if (!is_array($localValue)) {
+                $localValue = [$localValue];
+            }
+            $value = array();
 
-                if (in_array($fieldType, ['metafields', 'variant metafields'])) {
-                    array_push($value, [
-                        'namespace' => $remoteFieldPath[0],
-                        'fieldName' => $remoteFieldPath[1],
-                        'value' => $localValue
-                    ]);
-                } elseif (!in_array($fieldType, ["image"])) {
-                    $value[$remoteAttribute] = $localValue;
-                } else {
-                    $value = $localValue;
-                }
-                if (count($value) > 0) {
-                    $returnMap[$fieldType] = array_merge($returnMap[$fieldType] ?? [], $value);
-                }
+            if (in_array($fieldType, ['metafields', 'variant metafields'])) {
+                array_push($value, [
+                    'namespace' => $remoteFieldPath[0],
+                    'fieldName' => $remoteFieldPath[1],
+                    'value' => $localValue
+                ]);
+            } elseif (!in_array($fieldType, ["image"])) {
+                $value[$remoteAttribute] = $localValue;
+            } else {
+                $value = $localValue;
+            }
+            if (count($value) > 0) {
+                $returnMap[$fieldType] = array_merge($returnMap[$fieldType] ?? [], $value);
             }
         }
         return $returnMap;


### PR DESCRIPTION
Allow null/empty mapped fields to be passed to data mutation queries for Shopify; added logic to handle specific null/empty checks on each attribute and metafield.
Also - consistently logging GraphQL sent and received to Application Logger in File Objects.