### PR TITLE
Addresses 3 specific Shopify Errors

### DIFF
--- a/src/Services/Stores/BaseStore.php
+++ b/src/Services/Stores/BaseStore.php
@@ -98,10 +98,20 @@ abstract class BaseStore implements StoreInterface
             } else {
                 $value = $localValue;
             }
+
+            // these remote fields may not be set to empty values
+            foreach ($value as $key => $val) {
+                // note the test is typed, so a zero value is not considered empty
+                if( in_array($remoteAttribute, ['compareAtPrice', 'price', 'cost']) && ($val === '') )
+                    unset($value[$key]);
+            }
+
             if (count($value) > 0) {
                 $returnMap[$fieldType] = array_merge($returnMap[$fieldType] ?? [], $value);
             }
         }
+
+        
         return $returnMap;
     }
 

--- a/src/Services/Stores/ShopifyStore.php
+++ b/src/Services/Stores/ShopifyStore.php
@@ -309,19 +309,15 @@ class ShopifyStore extends BaseStore
                     break;
 
                 case 'weight':
-                    // this would require the unit mapping to be set before the value mapping
-                    if( isset($thisVariantArray['inventoryItem']['measurement']['weight']['unit']) ) {
-                        $thisVariantArray['inventoryItem']['measurement']['weight']['value'] = floatval($value[0]);
-                    } 
-                    
+                    $thisVariantArray['inventoryItem']['measurement']['weight']['value'] = floatval($value[0]);
                     break;
 
                 case 'weightUnit':
                     if( $value[0] ) {
                         $unit = strtoupper($value[0]);
-                        if (!in_array($unit, ['POUNDS', 'OUNCES', 'KILOGRAMS', 'GRAMS'])) {
-                            throw new Exception("invalid weightUnit value $unit not one of POUNDS OUNCES KILOGRAMS or GRAMS");
-                        }
+                        if (!in_array($unit, ['POUNDS', 'OUNCES', 'KILOGRAMS', 'GRAMS']))
+                            break;
+
 
                         $thisVariantArray['inventoryItem']['measurement']['weight']['unit'] = $unit;
                     }
@@ -363,6 +359,12 @@ class ShopifyStore extends BaseStore
         // do not send weight without unit
         if( !isset($thisVariantArray['inventoryItem']['measurement']['weight']['unit']) ) {
             unset($thisVariantArray['inventoryItem']['measurement']['weight']['value']);
+        } else {
+            // do not send unit without weight
+            if( $thisVariantArray['inventoryItem']['measurement']['weight']['value'] <= 0 ) {
+                // removes both unit and value
+                unset($thisVariantArray['inventoryItem']['measurement']['weight']);
+            }
         }
 
         // do not send empty array

--- a/src/Services/Stores/ShopifyStore.php
+++ b/src/Services/Stores/ShopifyStore.php
@@ -751,7 +751,7 @@ class ShopifyStore extends BaseStore
             $shopifyFileStatus = $this->shopifyQueryService->linkImageToProduct($shopifyFileId, $shopifyProductId);
 
             if( $shopifyFileStatus == self::STATUS_ERROR ) {
-                $this->applicationLogger->error("Error attaching image to product: " . $shopifyFileId . " to product: " . $shopifyProductId, [
+                $this->applicationLogger->error("Error attaching READY image to product: " . $shopifyFileId . " to product: " . $shopifyProductId, [
                     'component' => $this->configLogName,
                     null,
                 ]);

--- a/src/Services/Stores/ShopifyStore.php
+++ b/src/Services/Stores/ShopifyStore.php
@@ -315,10 +315,16 @@ class ShopifyStore extends BaseStore
                 case 'weightUnit':
                     if( $value[0] ) {
                         $unit = strtoupper($value[0]);
-                        if (!in_array($unit, ['POUNDS', 'OUNCES', 'KILOGRAMS', 'GRAMS']))
-                            break;
-
-
+                        // these are the only valid values on Shopify
+                        if (!in_array($unit, ['POUNDS', 'OUNCES', 'KILOGRAMS', 'GRAMS'])) {
+                            
+                            if( $unit == 'KG' ) $unit = 'KILOGRAMS';
+                            elseif( $unit == 'OZ' ) $unit = 'OUNCES';
+                            elseif( $unit == 'LB' || $unit == 'LBS' ) $unit = 'POUNDS';
+                            elseif( $unit == 'G' ) $unit = 'GRAMS';
+                            else break; // this will prevent the invalid unit from being sent to Shopify
+                        }
+                            
                         $thisVariantArray['inventoryItem']['measurement']['weight']['unit'] = $unit;
                     }
 

--- a/src/Utility/ShopifyQueryService.php
+++ b/src/Utility/ShopifyQueryService.php
@@ -714,13 +714,15 @@ class ShopifyQueryService
         ]);
 
         if( $response 
-            && isset($response['data']['userErrors'])
-            && is_array($response['data']['userErrors'])
-            && count($response['data']['userErrors']) )
+            && isset($response['data']['fileUpdate']['userErrors'])
+            && is_array($response['data']['fileUpdate']['userErrors'])
+            && count($response['data']['fileUpdate']['userErrors']) )
         {
             // if we have an error, and the file is not ready, ignore the error so we can retry
-            if( is_array($response['data']['files']) && count($response['data']['files']) ) {
-                $fileStatus = $response['data']['files'][0]['fileStatus'] ?: '';
+            if( is_array($response['data']['fileUpdate']['files']) 
+                && count($response['data']['fileUpdate']['files']) ) 
+            {
+                $fileStatus = $response['data']['fileUpdate']['files'][0]['fileStatus'] ?: '';
                 if( $fileStatus != 'READY' )
                     return $fileStatus;
             }


### PR DESCRIPTION
Prevent empty compareAtPrice, measurement weight and/or unit.
Avoid logging error on linking that succeeds