### PR TITLE
Separate handling of images vs new images

### DIFF
--- a/src/EventListener/OnAssetSaveListener.php
+++ b/src/EventListener/OnAssetSaveListener.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TorqIT\StoreSyndicatorBundle\EventListener;
+
+
+class OnAssetSaveListener
+{
+    // Assets in Pimcore that have been linked to a Shopify product will have an attribute `shopifyId` set.
+    // This listener will remove the `shopifyId` attribute from the asset when it is saved.
+    // Because the property has been removed, the asset will be re-uploaded to Shopify on the next sync.
+    public function removeShopifyFileId(\Pimcore\Event\Model\AssetEvent $event): void
+    {
+        $asset = $event->getAsset();
+        
+        $asset->removeProperty('shopifyFileId');
+        $asset->removeProperty('shopifyUploadStatus');
+        $asset->removeProperty('shopifyFileStatus');
+    }
+}

--- a/src/MessageHandler/ShopifyUploadImageMessageHandler.php
+++ b/src/MessageHandler/ShopifyUploadImageMessageHandler.php
@@ -64,7 +64,7 @@ final class ShopifyUploadImageMessageHandler
             // if these are empty, we cannot continue
             if( empty($shopifyFileId) ) {
                 $this->applicationLogger->error(
-                    "ShopifyUploadImageMessageHandler: Missing ShopifyFileId ({$message->assetId}) after upload", [
+                    "ShopifyUploadImageMessageHandler: Upload failed; missing ShopifyFileId ({$message->assetId})", [
                         'component' => $this->shopifyStore->configLogName
                     ]
                 );

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -17,6 +17,11 @@ services:
     tags:
       - { name: kernel.event_listener, event: pimcore.admin.object.list.beforeListLoad, method: onBeforeListLoad }
 
+
+  TorqIT\StoreSyndicatorBundle\EventListener\OnAssetSaveListener:
+    tags:
+      - { name: kernel.event_listener, event: pimcore.asset.preUpdate, method: removeShopifyFileId }
+
   # controllers are imported separately to make sure they're public
   # and have a tag that allows actions to type-hint services
   TorqIT\StoreSyndicatorBundle\Controller\:


### PR DESCRIPTION
If the image has already been uploaded to Shopify, just link it to the product.
If the image is already linked, do nothing.
Whenever an image is saved in PIM, remove the attributes so that it will be syndicated.