### PR TITLE
Bulk Variant Update query

### DIFF
--- a/src/Utility/shopify-queries/update-bulk-variants.graphql
+++ b/src/Utility/shopify-queries/update-bulk-variants.graphql
@@ -1,5 +1,17 @@
-mutation productVariantsBulkUpdate($productId: ID!, $variants: [ProductVariantsBulkInput!]!) {
-  productVariantsBulkUpdate(allowPartialUpdates: true, productId: $productId, variants: $variants) {
+mutation productVariantsBulkUpdate(
+  $productId: ID!
+  $variants: [ProductVariantsBulkInput!]!
+) {
+  productVariantsBulkUpdate(productId: $productId, variants: $variants) {
+    product {
+      id
+    }
+    productVariants {
+      id
+      metafield(namespace: "custom", key: "pimcore_id") {
+        value
+      }
+    }
     userErrors {
       field
       message


### PR DESCRIPTION
Modify Shopify API query format
Copy logic to remove empty money fields from create to update variants
